### PR TITLE
NuCivic/dkan#464 Improve logic for displaying title or not on site pages

### DIFF
--- a/templates/page/page.tpl.php
+++ b/templates/page/page.tpl.php
@@ -53,7 +53,7 @@
               <?php print render($main_menu); ?>
             </ul>
           <?php endif; ?>
-          
+
           <!-- user menu -->
           <?php
             $block = block_load('dkan_sitewide', 'dkan_sitewide_user_menu');
@@ -80,10 +80,10 @@
 
     <div class="main-row">
 
-      <section> 
+      <section>
         <a id="main-content"></a>
         <?php print render($title_prefix); ?>
-        <?php if (!empty($title) && (arg(0) == 'admin' || arg(1) == 'add' || arg(1) == 'edit')): ?>
+        <?php if (!empty($title) && empty($is_panel)): ?>
           <h1 class="page-header"><?php print $title; ?></h1>
         <?php endif; ?>
         <?php print render($title_suffix); ?>


### PR DESCRIPTION
Acceptance test 
- [x] Title shows once and only once on dataset, resource and search pages (panel pages)
- [x] Title shows once and only once on all other pages

Or is there a reason to remove title on other pages where it is not supplied by a panel?
