### PR TITLE
NuCivic/internal#907 Add styles to remove tab members

### DIFF
--- a/assets/sass/partials/_node.scss
+++ b/assets/sass/partials/_node.scss
@@ -194,7 +194,7 @@
   position:relative;
   .icon-info-sign:before {
     color:$gray-light;
-    content:"\f05a"; 
+    content:"\f05a";
     font-family:$icon-fa;
     font-size:2.5em;
     font-style: normal;
@@ -209,13 +209,15 @@
 }
 
 .node-type-group {
-  .radix-layouts-content .pane-content {
-    padding: 0;
-  }
   .horizontal-tabs {
     margin: 0;
   }
 }
+
+.group-owner-message {
+  margin-bottom:20px;
+}
+
 .field-type-text-with-summary {
   padding: 0;
 }

--- a/assets/stylesheets/compass_radix/fontawesome/font-awesome.css
+++ b/assets/stylesheets/compass_radix/fontawesome/font-awesome.css
@@ -1,14 +1,14 @@
 @charset "UTF-8";
 /*!
- *  Font Awesome 4.2.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  Font Awesome 4.3.0 by @davegandy - http://fontawesome.io - @fontawesome
  *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
  */
 /* FONT PATH -------------------------- */
-@font-face { font-family: 'FontAwesome'; src: url("../fonts/fontawesome-webfont.eot?v=4.2.0"); src: url("../fonts/fontawesome-webfont.eot?#iefix&v=4.2.0") format("embedded-opentype"), url("../fonts/fontawesome-webfont.woff?v=4.2.0") format("woff"), url("../fonts/fontawesome-webfont.ttf?v=4.2.0") format("truetype"), url("../fonts/fontawesome-webfont.svg?v=4.2.0#fontawesomeregular") format("svg"); font-weight: normal; font-style: normal; }
-.fa { display: inline-block; font: normal normal normal 14px/1 FontAwesome; font-size: inherit; text-rendering: auto; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+@font-face { font-family: 'FontAwesome'; src: url("../fonts/fontawesome-webfont.eot?v=4.3.0"); src: url("../fonts/fontawesome-webfont.eot?#iefix&v=4.3.0") format("embedded-opentype"), url("../fonts/fontawesome-webfont.woff2?v=4.3.0") format("woff2"), url("../fonts/fontawesome-webfont.woff?v=4.3.0") format("woff"), url("../fonts/fontawesome-webfont.ttf?v=4.3.0") format("truetype"), url("../fonts/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular") format("svg"); font-weight: normal; font-style: normal; }
+.fa { display: inline-block; font: normal normal normal 14px/1 FontAwesome; font-size: inherit; text-rendering: auto; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; transform: translate(0, 0); }
 
 /* makes the font 33% larger relative to the icon container */
-.fa-lg { font-size: 1.3333333333em; line-height: 0.75em; vertical-align: -15%; }
+.fa-lg { font-size: 1.33333333em; line-height: 0.75em; vertical-align: -15%; }
 
 .fa-2x { font-size: 2em; }
 
@@ -18,13 +18,13 @@
 
 .fa-5x { font-size: 5em; }
 
-.fa-fw { width: 1.2857142857em; text-align: center; }
+.fa-fw { width: 1.28571429em; text-align: center; }
 
-.fa-ul { padding-left: 0; margin-left: 2.1428571429em; list-style-type: none; }
+.fa-ul { padding-left: 0; margin-left: 2.14285714em; list-style-type: none; }
 .fa-ul > li { position: relative; }
 
-.fa-li { position: absolute; left: -2.1428571429em; width: 2.1428571429em; top: 0.1428571429em; text-align: center; }
-.fa-li.fa-lg { left: -1.8571428571em; }
+.fa-li { position: absolute; left: -2.14285714em; width: 2.14285714em; top: 0.14285714em; text-align: center; }
+.fa-li.fa-lg { left: -1.85714286em; }
 
 .fa-border { padding: .2em .25em .15em; border: solid 0.08em #eee; border-radius: .1em; }
 
@@ -36,6 +36,8 @@
 .fa.pull-right { margin-left: .3em; }
 
 .fa-spin { -webkit-animation: fa-spin 2s infinite linear; animation: fa-spin 2s infinite linear; }
+
+.fa-pulse { -webkit-animation: fa-spin 1s infinite steps(8); animation: fa-spin 1s infinite steps(8); }
 
 @-webkit-keyframes fa-spin { 0% { -webkit-transform: rotate(0deg); transform: rotate(0deg); }
   100% { -webkit-transform: rotate(359deg); transform: rotate(359deg); } }
@@ -354,7 +356,7 @@
 
 .fa-twitter:before { content: ""; }
 
-.fa-facebook:before { content: ""; }
+.fa-facebook-f:before, .fa-facebook:before { content: ""; }
 
 .fa-github:before { content: ""; }
 
@@ -764,7 +766,7 @@
 
 .fa-male:before { content: ""; }
 
-.fa-gittip:before { content: ""; }
+.fa-gittip:before, .fa-gratipay:before { content: ""; }
 
 .fa-sun-o:before { content: ""; }
 
@@ -928,7 +930,7 @@
 
 .fa-history:before { content: ""; }
 
-.fa-circle-thin:before { content: ""; }
+.fa-genderless:before, .fa-circle-thin:before { content: ""; }
 
 .fa-header:before { content: ""; }
 
@@ -1021,3 +1023,83 @@
 .fa-shekel:before, .fa-sheqel:before, .fa-ils:before { content: ""; }
 
 .fa-meanpath:before { content: ""; }
+
+.fa-buysellads:before { content: ""; }
+
+.fa-connectdevelop:before { content: ""; }
+
+.fa-dashcube:before { content: ""; }
+
+.fa-forumbee:before { content: ""; }
+
+.fa-leanpub:before { content: ""; }
+
+.fa-sellsy:before { content: ""; }
+
+.fa-shirtsinbulk:before { content: ""; }
+
+.fa-simplybuilt:before { content: ""; }
+
+.fa-skyatlas:before { content: ""; }
+
+.fa-cart-plus:before { content: ""; }
+
+.fa-cart-arrow-down:before { content: ""; }
+
+.fa-diamond:before { content: ""; }
+
+.fa-ship:before { content: ""; }
+
+.fa-user-secret:before { content: ""; }
+
+.fa-motorcycle:before { content: ""; }
+
+.fa-street-view:before { content: ""; }
+
+.fa-heartbeat:before { content: ""; }
+
+.fa-venus:before { content: ""; }
+
+.fa-mars:before { content: ""; }
+
+.fa-mercury:before { content: ""; }
+
+.fa-transgender:before { content: ""; }
+
+.fa-transgender-alt:before { content: ""; }
+
+.fa-venus-double:before { content: ""; }
+
+.fa-mars-double:before { content: ""; }
+
+.fa-venus-mars:before { content: ""; }
+
+.fa-mars-stroke:before { content: ""; }
+
+.fa-mars-stroke-v:before { content: ""; }
+
+.fa-mars-stroke-h:before { content: ""; }
+
+.fa-neuter:before { content: ""; }
+
+.fa-facebook-official:before { content: ""; }
+
+.fa-pinterest-p:before { content: ""; }
+
+.fa-whatsapp:before { content: ""; }
+
+.fa-server:before { content: ""; }
+
+.fa-user-plus:before { content: ""; }
+
+.fa-user-times:before { content: ""; }
+
+.fa-hotel:before, .fa-bed:before { content: ""; }
+
+.fa-viacoin:before { content: ""; }
+
+.fa-train:before { content: ""; }
+
+.fa-subway:before { content: ""; }
+
+.fa-medium:before { content: ""; }

--- a/assets/stylesheets/screen.css
+++ b/assets/stylesheets/screen.css
@@ -107,7 +107,7 @@ td, th { padding: 0; }
   .table { border-collapse: collapse !important; }
   .table td, .table th { background-color: #fff !important; }
   .table-bordered th, .calendar-calendar table.mini th, .table-bordered td, .calendar-calendar table.mini td { border: 1px solid #ddd !important; } }
-@font-face { font-family: 'Glyphicons Halflings'; src: url("bootstrap/glyphicons-halflings-regular.eot"); src: url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg"); }
+@font-face { font-family: 'Glyphicons Halflings'; src: url("bootstrap/glyphicons-halflings-regular.eot"); src: url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("bootstrap/glyphicons-halflings-regular.woff2") format("woff2"), url("bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg"); }
 .glyphicon { position: relative; top: 1px; display: inline-block; font-family: 'Glyphicons Halflings'; font-style: normal; font-weight: normal; line-height: 1; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
 .glyphicon-asterisk:before { content: "\2a"; }
@@ -510,6 +510,130 @@ td, th { padding: 0; }
 
 .glyphicon-tree-deciduous:before { content: "\e200"; }
 
+.glyphicon-cd:before { content: "\e201"; }
+
+.glyphicon-save-file:before { content: "\e202"; }
+
+.glyphicon-open-file:before { content: "\e203"; }
+
+.glyphicon-level-up:before { content: "\e204"; }
+
+.glyphicon-copy:before { content: "\e205"; }
+
+.glyphicon-paste:before { content: "\e206"; }
+
+.glyphicon-alert:before { content: "\e209"; }
+
+.glyphicon-equalizer:before { content: "\e210"; }
+
+.glyphicon-king:before { content: "\e211"; }
+
+.glyphicon-queen:before { content: "\e212"; }
+
+.glyphicon-pawn:before { content: "\e213"; }
+
+.glyphicon-bishop:before { content: "\e214"; }
+
+.glyphicon-knight:before { content: "\e215"; }
+
+.glyphicon-baby-formula:before { content: "\e216"; }
+
+.glyphicon-tent:before { content: "\26fa"; }
+
+.glyphicon-blackboard:before { content: "\e218"; }
+
+.glyphicon-bed:before { content: "\e219"; }
+
+.glyphicon-apple:before { content: "\f8ff"; }
+
+.glyphicon-erase:before { content: "\e221"; }
+
+.glyphicon-hourglass:before { content: "\231b"; }
+
+.glyphicon-lamp:before { content: "\e223"; }
+
+.glyphicon-duplicate:before { content: "\e224"; }
+
+.glyphicon-piggy-bank:before { content: "\e225"; }
+
+.glyphicon-scissors:before { content: "\e226"; }
+
+.glyphicon-bitcoin:before { content: "\e227"; }
+
+.glyphicon-btc:before { content: "\e227"; }
+
+.glyphicon-xbt:before { content: "\e227"; }
+
+.glyphicon-yen:before { content: "\00a5"; }
+
+.glyphicon-jpy:before { content: "\00a5"; }
+
+.glyphicon-ruble:before { content: "\20bd"; }
+
+.glyphicon-rub:before { content: "\20bd"; }
+
+.glyphicon-scale:before { content: "\e230"; }
+
+.glyphicon-ice-lolly:before { content: "\e231"; }
+
+.glyphicon-ice-lolly-tasted:before { content: "\e232"; }
+
+.glyphicon-education:before { content: "\e233"; }
+
+.glyphicon-option-horizontal:before { content: "\e234"; }
+
+.glyphicon-option-vertical:before { content: "\e235"; }
+
+.glyphicon-menu-hamburger:before { content: "\e236"; }
+
+.glyphicon-modal-window:before { content: "\e237"; }
+
+.glyphicon-oil:before { content: "\e238"; }
+
+.glyphicon-grain:before { content: "\e239"; }
+
+.glyphicon-sunglasses:before { content: "\e240"; }
+
+.glyphicon-text-size:before { content: "\e241"; }
+
+.glyphicon-text-color:before { content: "\e242"; }
+
+.glyphicon-text-background:before { content: "\e243"; }
+
+.glyphicon-object-align-top:before { content: "\e244"; }
+
+.glyphicon-object-align-bottom:before { content: "\e245"; }
+
+.glyphicon-object-align-horizontal:before { content: "\e246"; }
+
+.glyphicon-object-align-left:before { content: "\e247"; }
+
+.glyphicon-object-align-vertical:before { content: "\e248"; }
+
+.glyphicon-object-align-right:before { content: "\e249"; }
+
+.glyphicon-triangle-right:before { content: "\e250"; }
+
+.glyphicon-triangle-left:before { content: "\e251"; }
+
+.glyphicon-triangle-bottom:before { content: "\e252"; }
+
+.glyphicon-triangle-top:before { content: "\e253"; }
+
+.glyphicon-console:before { content: "\e254"; }
+
+.glyphicon-superscript:before { content: "\e255"; }
+
+.glyphicon-subscript:before { content: "\e256"; }
+
+.glyphicon-menu-left:before { content: "\e257"; }
+
+.glyphicon-menu-right:before { content: "\e258"; }
+
+.glyphicon-menu-down:before { content: "\e259"; }
+
+.glyphicon-menu-up:before { content: "\e260"; }
+
 * { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; }
 
 *:before, *:after { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; }
@@ -541,6 +665,8 @@ hr { margin-top: 32px; margin-bottom: 32px; border: 0; border-top: 1px solid #ee
 .sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); border: 0; }
 
 .sr-only-focusable:active, .sr-only-focusable:focus { position: static; width: auto; height: auto; margin: 0; overflow: visible; clip: auto; }
+
+[role="button"] { cursor: pointer; }
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 { font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif; font-weight: 500; line-height: 1.3; color: inherit; }
 h1 small, h1 .small, h2 small, h2 .small, h3 small, h3 .small, h4 small, h4 .small, h5 small, h5 .small, h6 small, h6 .small, .h1 small, .h1 .small, .h2 small, .h2 .small, .h3 small, .h3 .small, .h4 small, .h4 .small, .h5 small, .h5 .small, .h6 small, .h6 .small { font-weight: normal; line-height: 1; color: #999999; }
@@ -584,7 +710,7 @@ mark, .mark { background-color: #fcf8e3; padding: .2em; }
 
 .text-lowercase { text-transform: lowercase; }
 
-.text-uppercase { text-transform: uppercase; }
+.text-uppercase, .initialism { text-transform: uppercase; }
 
 .text-capitalize { text-transform: capitalize; }
 
@@ -657,7 +783,7 @@ dd { margin-left: 0; }
 
 abbr[title], abbr[data-original-title] { cursor: help; border-bottom: 1px dotted #999999; }
 
-.initialism { font-size: 90%; text-transform: uppercase; }
+.initialism { font-size: 90%; }
 
 blockquote { padding: 16px 32px; margin: 0 0 32px; font-size: 20px; border-left: 5px solid #eeeeee; }
 blockquote p:last-child, blockquote ul:last-child, blockquote ol:last-child { margin-bottom: 0; }
@@ -701,263 +827,263 @@ pre code { padding: 0; font-size: inherit; color: inherit; white-space: pre-wrap
 
 .col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 { float: left; }
 
-.col-xs-1 { width: 8.3333333333%; }
+.col-xs-1 { width: 8.33333333%; }
 
-.col-xs-2 { width: 16.6666666667%; }
+.col-xs-2 { width: 16.66666667%; }
 
 .col-xs-3 { width: 25%; }
 
-.col-xs-4 { width: 33.3333333333%; }
+.col-xs-4 { width: 33.33333333%; }
 
-.col-xs-5 { width: 41.6666666667%; }
+.col-xs-5 { width: 41.66666667%; }
 
 .col-xs-6 { width: 50%; }
 
-.col-xs-7 { width: 58.3333333333%; }
+.col-xs-7 { width: 58.33333333%; }
 
-.col-xs-8 { width: 66.6666666667%; }
+.col-xs-8 { width: 66.66666667%; }
 
 .col-xs-9 { width: 75%; }
 
-.col-xs-10 { width: 83.3333333333%; }
+.col-xs-10 { width: 83.33333333%; }
 
-.col-xs-11 { width: 91.6666666667%; }
+.col-xs-11 { width: 91.66666667%; }
 
 .col-xs-12 { width: 100%; }
 
 .col-xs-pull-0 { right: auto; }
 
-.col-xs-pull-1 { right: 8.3333333333%; }
+.col-xs-pull-1 { right: 8.33333333%; }
 
-.col-xs-pull-2 { right: 16.6666666667%; }
+.col-xs-pull-2 { right: 16.66666667%; }
 
 .col-xs-pull-3 { right: 25%; }
 
-.col-xs-pull-4 { right: 33.3333333333%; }
+.col-xs-pull-4 { right: 33.33333333%; }
 
-.col-xs-pull-5 { right: 41.6666666667%; }
+.col-xs-pull-5 { right: 41.66666667%; }
 
 .col-xs-pull-6 { right: 50%; }
 
-.col-xs-pull-7 { right: 58.3333333333%; }
+.col-xs-pull-7 { right: 58.33333333%; }
 
-.col-xs-pull-8 { right: 66.6666666667%; }
+.col-xs-pull-8 { right: 66.66666667%; }
 
 .col-xs-pull-9 { right: 75%; }
 
-.col-xs-pull-10 { right: 83.3333333333%; }
+.col-xs-pull-10 { right: 83.33333333%; }
 
-.col-xs-pull-11 { right: 91.6666666667%; }
+.col-xs-pull-11 { right: 91.66666667%; }
 
 .col-xs-pull-12 { right: 100%; }
 
 .col-xs-push-0 { left: auto; }
 
-.col-xs-push-1 { left: 8.3333333333%; }
+.col-xs-push-1 { left: 8.33333333%; }
 
-.col-xs-push-2 { left: 16.6666666667%; }
+.col-xs-push-2 { left: 16.66666667%; }
 
 .col-xs-push-3 { left: 25%; }
 
-.col-xs-push-4 { left: 33.3333333333%; }
+.col-xs-push-4 { left: 33.33333333%; }
 
-.col-xs-push-5 { left: 41.6666666667%; }
+.col-xs-push-5 { left: 41.66666667%; }
 
 .col-xs-push-6 { left: 50%; }
 
-.col-xs-push-7 { left: 58.3333333333%; }
+.col-xs-push-7 { left: 58.33333333%; }
 
-.col-xs-push-8 { left: 66.6666666667%; }
+.col-xs-push-8 { left: 66.66666667%; }
 
 .col-xs-push-9 { left: 75%; }
 
-.col-xs-push-10 { left: 83.3333333333%; }
+.col-xs-push-10 { left: 83.33333333%; }
 
-.col-xs-push-11 { left: 91.6666666667%; }
+.col-xs-push-11 { left: 91.66666667%; }
 
 .col-xs-push-12 { left: 100%; }
 
 .col-xs-offset-0 { margin-left: 0%; }
 
-.col-xs-offset-1 { margin-left: 8.3333333333%; }
+.col-xs-offset-1 { margin-left: 8.33333333%; }
 
-.col-xs-offset-2 { margin-left: 16.6666666667%; }
+.col-xs-offset-2 { margin-left: 16.66666667%; }
 
 .col-xs-offset-3 { margin-left: 25%; }
 
-.col-xs-offset-4 { margin-left: 33.3333333333%; }
+.col-xs-offset-4 { margin-left: 33.33333333%; }
 
-.col-xs-offset-5 { margin-left: 41.6666666667%; }
+.col-xs-offset-5 { margin-left: 41.66666667%; }
 
 .col-xs-offset-6 { margin-left: 50%; }
 
-.col-xs-offset-7 { margin-left: 58.3333333333%; }
+.col-xs-offset-7 { margin-left: 58.33333333%; }
 
-.col-xs-offset-8 { margin-left: 66.6666666667%; }
+.col-xs-offset-8 { margin-left: 66.66666667%; }
 
 .col-xs-offset-9 { margin-left: 75%; }
 
-.col-xs-offset-10 { margin-left: 83.3333333333%; }
+.col-xs-offset-10 { margin-left: 83.33333333%; }
 
-.col-xs-offset-11 { margin-left: 91.6666666667%; }
+.col-xs-offset-11 { margin-left: 91.66666667%; }
 
 .col-xs-offset-12 { margin-left: 100%; }
 
 @media (min-width: 768px) { .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 { float: left; }
-  .col-sm-1 { width: 8.3333333333%; }
-  .col-sm-2 { width: 16.6666666667%; }
+  .col-sm-1 { width: 8.33333333%; }
+  .col-sm-2 { width: 16.66666667%; }
   .col-sm-3 { width: 25%; }
-  .col-sm-4 { width: 33.3333333333%; }
-  .col-sm-5 { width: 41.6666666667%; }
+  .col-sm-4 { width: 33.33333333%; }
+  .col-sm-5 { width: 41.66666667%; }
   .col-sm-6 { width: 50%; }
-  .col-sm-7 { width: 58.3333333333%; }
-  .col-sm-8 { width: 66.6666666667%; }
+  .col-sm-7 { width: 58.33333333%; }
+  .col-sm-8 { width: 66.66666667%; }
   .col-sm-9 { width: 75%; }
-  .col-sm-10 { width: 83.3333333333%; }
-  .col-sm-11 { width: 91.6666666667%; }
+  .col-sm-10 { width: 83.33333333%; }
+  .col-sm-11 { width: 91.66666667%; }
   .col-sm-12 { width: 100%; }
   .col-sm-pull-0 { right: auto; }
-  .col-sm-pull-1 { right: 8.3333333333%; }
-  .col-sm-pull-2 { right: 16.6666666667%; }
+  .col-sm-pull-1 { right: 8.33333333%; }
+  .col-sm-pull-2 { right: 16.66666667%; }
   .col-sm-pull-3 { right: 25%; }
-  .col-sm-pull-4 { right: 33.3333333333%; }
-  .col-sm-pull-5 { right: 41.6666666667%; }
+  .col-sm-pull-4 { right: 33.33333333%; }
+  .col-sm-pull-5 { right: 41.66666667%; }
   .col-sm-pull-6 { right: 50%; }
-  .col-sm-pull-7 { right: 58.3333333333%; }
-  .col-sm-pull-8 { right: 66.6666666667%; }
+  .col-sm-pull-7 { right: 58.33333333%; }
+  .col-sm-pull-8 { right: 66.66666667%; }
   .col-sm-pull-9 { right: 75%; }
-  .col-sm-pull-10 { right: 83.3333333333%; }
-  .col-sm-pull-11 { right: 91.6666666667%; }
+  .col-sm-pull-10 { right: 83.33333333%; }
+  .col-sm-pull-11 { right: 91.66666667%; }
   .col-sm-pull-12 { right: 100%; }
   .col-sm-push-0 { left: auto; }
-  .col-sm-push-1 { left: 8.3333333333%; }
-  .col-sm-push-2 { left: 16.6666666667%; }
+  .col-sm-push-1 { left: 8.33333333%; }
+  .col-sm-push-2 { left: 16.66666667%; }
   .col-sm-push-3 { left: 25%; }
-  .col-sm-push-4 { left: 33.3333333333%; }
-  .col-sm-push-5 { left: 41.6666666667%; }
+  .col-sm-push-4 { left: 33.33333333%; }
+  .col-sm-push-5 { left: 41.66666667%; }
   .col-sm-push-6 { left: 50%; }
-  .col-sm-push-7 { left: 58.3333333333%; }
-  .col-sm-push-8 { left: 66.6666666667%; }
+  .col-sm-push-7 { left: 58.33333333%; }
+  .col-sm-push-8 { left: 66.66666667%; }
   .col-sm-push-9 { left: 75%; }
-  .col-sm-push-10 { left: 83.3333333333%; }
-  .col-sm-push-11 { left: 91.6666666667%; }
+  .col-sm-push-10 { left: 83.33333333%; }
+  .col-sm-push-11 { left: 91.66666667%; }
   .col-sm-push-12 { left: 100%; }
   .col-sm-offset-0 { margin-left: 0%; }
-  .col-sm-offset-1 { margin-left: 8.3333333333%; }
-  .col-sm-offset-2 { margin-left: 16.6666666667%; }
+  .col-sm-offset-1 { margin-left: 8.33333333%; }
+  .col-sm-offset-2 { margin-left: 16.66666667%; }
   .col-sm-offset-3 { margin-left: 25%; }
-  .col-sm-offset-4 { margin-left: 33.3333333333%; }
-  .col-sm-offset-5 { margin-left: 41.6666666667%; }
+  .col-sm-offset-4 { margin-left: 33.33333333%; }
+  .col-sm-offset-5 { margin-left: 41.66666667%; }
   .col-sm-offset-6 { margin-left: 50%; }
-  .col-sm-offset-7 { margin-left: 58.3333333333%; }
-  .col-sm-offset-8 { margin-left: 66.6666666667%; }
+  .col-sm-offset-7 { margin-left: 58.33333333%; }
+  .col-sm-offset-8 { margin-left: 66.66666667%; }
   .col-sm-offset-9 { margin-left: 75%; }
-  .col-sm-offset-10 { margin-left: 83.3333333333%; }
-  .col-sm-offset-11 { margin-left: 91.6666666667%; }
+  .col-sm-offset-10 { margin-left: 83.33333333%; }
+  .col-sm-offset-11 { margin-left: 91.66666667%; }
   .col-sm-offset-12 { margin-left: 100%; } }
 @media (min-width: 992px) { .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12, .calendar-calendar, .view .row > .list-group { float: left; }
-  .col-md-1 { width: 8.3333333333%; }
-  .col-md-2 { width: 16.6666666667%; }
+  .col-md-1 { width: 8.33333333%; }
+  .col-md-2 { width: 16.66666667%; }
   .col-md-3 { width: 25%; }
-  .col-md-4 { width: 33.3333333333%; }
-  .col-md-5 { width: 41.6666666667%; }
+  .col-md-4 { width: 33.33333333%; }
+  .col-md-5 { width: 41.66666667%; }
   .col-md-6 { width: 50%; }
-  .col-md-7 { width: 58.3333333333%; }
-  .col-md-8 { width: 66.6666666667%; }
+  .col-md-7 { width: 58.33333333%; }
+  .col-md-8 { width: 66.66666667%; }
   .col-md-9 { width: 75%; }
-  .col-md-10 { width: 83.3333333333%; }
-  .col-md-11 { width: 91.6666666667%; }
+  .col-md-10 { width: 83.33333333%; }
+  .col-md-11 { width: 91.66666667%; }
   .col-md-12, .calendar-calendar, .view .row > .list-group { width: 100%; }
   .col-md-pull-0 { right: auto; }
-  .col-md-pull-1 { right: 8.3333333333%; }
-  .col-md-pull-2 { right: 16.6666666667%; }
+  .col-md-pull-1 { right: 8.33333333%; }
+  .col-md-pull-2 { right: 16.66666667%; }
   .col-md-pull-3 { right: 25%; }
-  .col-md-pull-4 { right: 33.3333333333%; }
-  .col-md-pull-5 { right: 41.6666666667%; }
+  .col-md-pull-4 { right: 33.33333333%; }
+  .col-md-pull-5 { right: 41.66666667%; }
   .col-md-pull-6 { right: 50%; }
-  .col-md-pull-7 { right: 58.3333333333%; }
-  .col-md-pull-8 { right: 66.6666666667%; }
+  .col-md-pull-7 { right: 58.33333333%; }
+  .col-md-pull-8 { right: 66.66666667%; }
   .col-md-pull-9 { right: 75%; }
-  .col-md-pull-10 { right: 83.3333333333%; }
-  .col-md-pull-11 { right: 91.6666666667%; }
+  .col-md-pull-10 { right: 83.33333333%; }
+  .col-md-pull-11 { right: 91.66666667%; }
   .col-md-pull-12 { right: 100%; }
   .col-md-push-0 { left: auto; }
-  .col-md-push-1 { left: 8.3333333333%; }
-  .col-md-push-2 { left: 16.6666666667%; }
+  .col-md-push-1 { left: 8.33333333%; }
+  .col-md-push-2 { left: 16.66666667%; }
   .col-md-push-3 { left: 25%; }
-  .col-md-push-4 { left: 33.3333333333%; }
-  .col-md-push-5 { left: 41.6666666667%; }
+  .col-md-push-4 { left: 33.33333333%; }
+  .col-md-push-5 { left: 41.66666667%; }
   .col-md-push-6 { left: 50%; }
-  .col-md-push-7 { left: 58.3333333333%; }
-  .col-md-push-8 { left: 66.6666666667%; }
+  .col-md-push-7 { left: 58.33333333%; }
+  .col-md-push-8 { left: 66.66666667%; }
   .col-md-push-9 { left: 75%; }
-  .col-md-push-10 { left: 83.3333333333%; }
-  .col-md-push-11 { left: 91.6666666667%; }
+  .col-md-push-10 { left: 83.33333333%; }
+  .col-md-push-11 { left: 91.66666667%; }
   .col-md-push-12 { left: 100%; }
   .col-md-offset-0 { margin-left: 0%; }
-  .col-md-offset-1 { margin-left: 8.3333333333%; }
-  .col-md-offset-2 { margin-left: 16.6666666667%; }
+  .col-md-offset-1 { margin-left: 8.33333333%; }
+  .col-md-offset-2 { margin-left: 16.66666667%; }
   .col-md-offset-3 { margin-left: 25%; }
-  .col-md-offset-4 { margin-left: 33.3333333333%; }
-  .col-md-offset-5 { margin-left: 41.6666666667%; }
+  .col-md-offset-4 { margin-left: 33.33333333%; }
+  .col-md-offset-5 { margin-left: 41.66666667%; }
   .col-md-offset-6 { margin-left: 50%; }
-  .col-md-offset-7 { margin-left: 58.3333333333%; }
-  .col-md-offset-8 { margin-left: 66.6666666667%; }
+  .col-md-offset-7 { margin-left: 58.33333333%; }
+  .col-md-offset-8 { margin-left: 66.66666667%; }
   .col-md-offset-9 { margin-left: 75%; }
-  .col-md-offset-10 { margin-left: 83.3333333333%; }
-  .col-md-offset-11 { margin-left: 91.6666666667%; }
+  .col-md-offset-10 { margin-left: 83.33333333%; }
+  .col-md-offset-11 { margin-left: 91.66666667%; }
   .col-md-offset-12 { margin-left: 100%; } }
 @media (min-width: 1200px) { .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 { float: left; }
-  .col-lg-1 { width: 8.3333333333%; }
-  .col-lg-2 { width: 16.6666666667%; }
+  .col-lg-1 { width: 8.33333333%; }
+  .col-lg-2 { width: 16.66666667%; }
   .col-lg-3 { width: 25%; }
-  .col-lg-4 { width: 33.3333333333%; }
-  .col-lg-5 { width: 41.6666666667%; }
+  .col-lg-4 { width: 33.33333333%; }
+  .col-lg-5 { width: 41.66666667%; }
   .col-lg-6 { width: 50%; }
-  .col-lg-7 { width: 58.3333333333%; }
-  .col-lg-8 { width: 66.6666666667%; }
+  .col-lg-7 { width: 58.33333333%; }
+  .col-lg-8 { width: 66.66666667%; }
   .col-lg-9 { width: 75%; }
-  .col-lg-10 { width: 83.3333333333%; }
-  .col-lg-11 { width: 91.6666666667%; }
+  .col-lg-10 { width: 83.33333333%; }
+  .col-lg-11 { width: 91.66666667%; }
   .col-lg-12 { width: 100%; }
   .col-lg-pull-0 { right: auto; }
-  .col-lg-pull-1 { right: 8.3333333333%; }
-  .col-lg-pull-2 { right: 16.6666666667%; }
+  .col-lg-pull-1 { right: 8.33333333%; }
+  .col-lg-pull-2 { right: 16.66666667%; }
   .col-lg-pull-3 { right: 25%; }
-  .col-lg-pull-4 { right: 33.3333333333%; }
-  .col-lg-pull-5 { right: 41.6666666667%; }
+  .col-lg-pull-4 { right: 33.33333333%; }
+  .col-lg-pull-5 { right: 41.66666667%; }
   .col-lg-pull-6 { right: 50%; }
-  .col-lg-pull-7 { right: 58.3333333333%; }
-  .col-lg-pull-8 { right: 66.6666666667%; }
+  .col-lg-pull-7 { right: 58.33333333%; }
+  .col-lg-pull-8 { right: 66.66666667%; }
   .col-lg-pull-9 { right: 75%; }
-  .col-lg-pull-10 { right: 83.3333333333%; }
-  .col-lg-pull-11 { right: 91.6666666667%; }
+  .col-lg-pull-10 { right: 83.33333333%; }
+  .col-lg-pull-11 { right: 91.66666667%; }
   .col-lg-pull-12 { right: 100%; }
   .col-lg-push-0 { left: auto; }
-  .col-lg-push-1 { left: 8.3333333333%; }
-  .col-lg-push-2 { left: 16.6666666667%; }
+  .col-lg-push-1 { left: 8.33333333%; }
+  .col-lg-push-2 { left: 16.66666667%; }
   .col-lg-push-3 { left: 25%; }
-  .col-lg-push-4 { left: 33.3333333333%; }
-  .col-lg-push-5 { left: 41.6666666667%; }
+  .col-lg-push-4 { left: 33.33333333%; }
+  .col-lg-push-5 { left: 41.66666667%; }
   .col-lg-push-6 { left: 50%; }
-  .col-lg-push-7 { left: 58.3333333333%; }
-  .col-lg-push-8 { left: 66.6666666667%; }
+  .col-lg-push-7 { left: 58.33333333%; }
+  .col-lg-push-8 { left: 66.66666667%; }
   .col-lg-push-9 { left: 75%; }
-  .col-lg-push-10 { left: 83.3333333333%; }
-  .col-lg-push-11 { left: 91.6666666667%; }
+  .col-lg-push-10 { left: 83.33333333%; }
+  .col-lg-push-11 { left: 91.66666667%; }
   .col-lg-push-12 { left: 100%; }
   .col-lg-offset-0 { margin-left: 0%; }
-  .col-lg-offset-1 { margin-left: 8.3333333333%; }
-  .col-lg-offset-2 { margin-left: 16.6666666667%; }
+  .col-lg-offset-1 { margin-left: 8.33333333%; }
+  .col-lg-offset-2 { margin-left: 16.66666667%; }
   .col-lg-offset-3 { margin-left: 25%; }
-  .col-lg-offset-4 { margin-left: 33.3333333333%; }
-  .col-lg-offset-5 { margin-left: 41.6666666667%; }
+  .col-lg-offset-4 { margin-left: 33.33333333%; }
+  .col-lg-offset-5 { margin-left: 41.66666667%; }
   .col-lg-offset-6 { margin-left: 50%; }
-  .col-lg-offset-7 { margin-left: 58.3333333333%; }
-  .col-lg-offset-8 { margin-left: 66.6666666667%; }
+  .col-lg-offset-7 { margin-left: 58.33333333%; }
+  .col-lg-offset-8 { margin-left: 66.66666667%; }
   .col-lg-offset-9 { margin-left: 75%; }
-  .col-lg-offset-10 { margin-left: 83.3333333333%; }
-  .col-lg-offset-11 { margin-left: 91.6666666667%; }
+  .col-lg-offset-10 { margin-left: 83.33333333%; }
+  .col-lg-offset-11 { margin-left: 91.66666667%; }
   .col-lg-offset-12 { margin-left: 100%; } }
 table { background-color: transparent; }
 
@@ -978,7 +1104,7 @@ th { text-align: left; }
 .table-bordered > thead > tr > th, .calendar-calendar table.mini > thead > tr > th, .table-bordered > thead > tr > td, .calendar-calendar table.mini > thead > tr > td, .table-bordered > tbody > tr > th, .calendar-calendar table.mini > tbody > tr > th, .table-bordered > tbody > tr > td, .calendar-calendar table.mini > tbody > tr > td, .table-bordered > tfoot > tr > th, .calendar-calendar table.mini > tfoot > tr > th, .table-bordered > tfoot > tr > td, .calendar-calendar table.mini > tfoot > tr > td { border: 1px solid #ddd; }
 .table-bordered > thead > tr > th, .calendar-calendar table.mini > thead > tr > th, .table-bordered > thead > tr > td, .calendar-calendar table.mini > thead > tr > td { border-bottom-width: 2px; }
 
-.table-striped > tbody > tr:nth-child(odd) { background-color: #f9f9f9; }
+.table-striped > tbody > tr:nth-of-type(odd) { background-color: #f9f9f9; }
 
 .table-hover > tbody > tr:hover { background-color: #f5f5f5; }
 
@@ -1040,15 +1166,16 @@ output { display: block; padding-top: 7px; font-size: 16px; line-height: 2; colo
 .form-control::-moz-placeholder { color: #999999; opacity: 1; }
 .form-control:-ms-input-placeholder { color: #999999; }
 .form-control::-webkit-input-placeholder { color: #999999; }
-.form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control { cursor: not-allowed; background-color: #eeeeee; opacity: 1; }
+.form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control { background-color: #eeeeee; opacity: 1; }
+.form-control[disabled], fieldset[disabled] .form-control { cursor: not-allowed; }
 
 textarea.form-control { height: auto; }
 
 input[type="search"] { -webkit-appearance: none; }
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) { input[type="date"], input[type="time"], input[type="datetime-local"], input[type="month"] { line-height: 46px; }
-  input[type="date"].input-sm, .input-group-sm > input[type="date"].form-control, .input-group-sm > input[type="date"].input-group-addon, .input-group-sm > .input-group-btn > input[type="date"].btn, input[type="time"].input-sm, .input-group-sm > input[type="time"].form-control, .input-group-sm > input[type="time"].input-group-addon, .input-group-sm > .input-group-btn > input[type="time"].btn, input[type="datetime-local"].input-sm, .input-group-sm > input[type="datetime-local"].form-control, .input-group-sm > input[type="datetime-local"].input-group-addon, .input-group-sm > .input-group-btn > input[type="datetime-local"].btn, input[type="month"].input-sm, .input-group-sm > input[type="month"].form-control, .input-group-sm > input[type="month"].input-group-addon, .input-group-sm > .input-group-btn > input[type="month"].btn { line-height: 33px; }
-  input[type="date"].input-lg, .input-group-lg > input[type="date"].form-control, .input-group-lg > input[type="date"].input-group-addon, .input-group-lg > .input-group-btn > input[type="date"].btn, input[type="time"].input-lg, .input-group-lg > input[type="time"].form-control, .input-group-lg > input[type="time"].input-group-addon, .input-group-lg > .input-group-btn > input[type="time"].btn, input[type="datetime-local"].input-lg, .input-group-lg > input[type="datetime-local"].form-control, .input-group-lg > input[type="datetime-local"].input-group-addon, .input-group-lg > .input-group-btn > input[type="datetime-local"].btn, input[type="month"].input-lg, .input-group-lg > input[type="month"].form-control, .input-group-lg > input[type="month"].input-group-addon, .input-group-lg > .input-group-btn > input[type="month"].btn { line-height: 49px; } }
+  input[type="date"].input-sm, .input-group-sm > input[type="date"].form-control, .input-group-sm > input[type="date"].input-group-addon, .input-group-sm > .input-group-btn > input[type="date"].btn, .input-group-sm input[type="date"], input[type="time"].input-sm, .input-group-sm > input[type="time"].form-control, .input-group-sm > input[type="time"].input-group-addon, .input-group-sm > .input-group-btn > input[type="time"].btn, .input-group-sm input[type="time"], input[type="datetime-local"].input-sm, .input-group-sm > input[type="datetime-local"].form-control, .input-group-sm > input[type="datetime-local"].input-group-addon, .input-group-sm > .input-group-btn > input[type="datetime-local"].btn, .input-group-sm input[type="datetime-local"], input[type="month"].input-sm, .input-group-sm > input[type="month"].form-control, .input-group-sm > input[type="month"].input-group-addon, .input-group-sm > .input-group-btn > input[type="month"].btn, .input-group-sm input[type="month"] { line-height: 33px; }
+  input[type="date"].input-lg, .input-group-lg > input[type="date"].form-control, .input-group-lg > input[type="date"].input-group-addon, .input-group-lg > .input-group-btn > input[type="date"].btn, .input-group-lg input[type="date"], input[type="time"].input-lg, .input-group-lg > input[type="time"].form-control, .input-group-lg > input[type="time"].input-group-addon, .input-group-lg > .input-group-btn > input[type="time"].btn, .input-group-lg input[type="time"], input[type="datetime-local"].input-lg, .input-group-lg > input[type="datetime-local"].form-control, .input-group-lg > input[type="datetime-local"].input-group-addon, .input-group-lg > .input-group-btn > input[type="datetime-local"].btn, .input-group-lg input[type="datetime-local"], input[type="month"].input-lg, .input-group-lg > input[type="month"].form-control, .input-group-lg > input[type="month"].input-group-addon, .input-group-lg > .input-group-btn > input[type="month"].btn, .input-group-lg input[type="month"] { line-height: 49px; } }
 .form-group { margin-bottom: 15px; }
 
 .radio, .checkbox { position: relative; display: block; margin-top: 10px; margin-bottom: 10px; }
@@ -1058,7 +1185,7 @@ input[type="search"] { -webkit-appearance: none; }
 
 .radio + .radio, .checkbox + .checkbox { margin-top: -5px; }
 
-.radio-inline, .checkbox-inline { display: inline-block; padding-left: 20px; margin-bottom: 0; vertical-align: middle; font-weight: normal; cursor: pointer; }
+.radio-inline, .checkbox-inline { position: relative; display: inline-block; padding-left: 20px; margin-bottom: 0; vertical-align: middle; font-weight: normal; cursor: pointer; }
 
 .radio-inline + .radio-inline, .checkbox-inline + .checkbox-inline { margin-top: 0; margin-left: 10px; }
 
@@ -1068,20 +1195,30 @@ input[type="radio"][disabled], input[type="radio"].disabled, fieldset[disabled] 
 
 .radio.disabled label, fieldset[disabled] .radio label, .checkbox.disabled label, fieldset[disabled] .checkbox label { cursor: not-allowed; }
 
-.form-control-static { padding-top: 7px; padding-bottom: 7px; margin-bottom: 0; }
+.form-control-static { padding-top: 7px; padding-bottom: 7px; margin-bottom: 0; min-height: 48px; }
 .form-control-static.input-lg, .input-group-lg > .form-control-static.form-control, .input-group-lg > .form-control-static.input-group-addon, .input-group-lg > .input-group-btn > .form-control-static.btn, .form-control-static.input-sm, .input-group-sm > .form-control-static.form-control, .input-group-sm > .form-control-static.input-group-addon, .input-group-sm > .input-group-btn > .form-control-static.btn { padding-left: 0; padding-right: 0; }
 
-.input-sm, .input-group-sm > .form-control, .input-group-sm > .input-group-addon, .input-group-sm > .input-group-btn > .btn, .form-group-sm .form-control { height: 33px; padding: 5px 10px; font-size: 14px; line-height: 1.5; border-radius: 3px; }
+.input-sm, .input-group-sm > .form-control, .input-group-sm > .input-group-addon, .input-group-sm > .input-group-btn > .btn { height: 33px; padding: 5px 10px; font-size: 14px; line-height: 1.5; border-radius: 3px; }
 
-select.input-sm, .input-group-sm > select.form-control, .input-group-sm > select.input-group-addon, .input-group-sm > .input-group-btn > select.btn, .form-group-sm .form-control { height: 33px; line-height: 33px; }
+select.input-sm, .input-group-sm > select.form-control, .input-group-sm > select.input-group-addon, .input-group-sm > .input-group-btn > select.btn { height: 33px; line-height: 33px; }
 
-textarea.input-sm, .input-group-sm > textarea.form-control, .input-group-sm > textarea.input-group-addon, .input-group-sm > .input-group-btn > textarea.btn, .form-group-sm .form-control, select[multiple].input-sm, .input-group-sm > select[multiple].form-control, .input-group-sm > select[multiple].input-group-addon, .input-group-sm > .input-group-btn > select[multiple].btn, .form-group-sm .form-control { height: auto; }
+textarea.input-sm, .input-group-sm > textarea.form-control, .input-group-sm > textarea.input-group-addon, .input-group-sm > .input-group-btn > textarea.btn, select[multiple].input-sm, .input-group-sm > select[multiple].form-control, .input-group-sm > select[multiple].input-group-addon, .input-group-sm > .input-group-btn > select[multiple].btn { height: auto; }
 
-.input-lg, .input-group-lg > .form-control, .input-group-lg > .input-group-addon, .input-group-lg > .input-group-btn > .btn, .form-group-lg .form-control { height: 49px; padding: 10px 16px; font-size: 20px; line-height: 1.33; border-radius: 6px; }
+.form-group-sm .form-control { height: 33px; padding: 5px 10px; font-size: 14px; line-height: 1.5; border-radius: 3px; }
+.form-group-sm select.form-control { height: 33px; line-height: 33px; }
+.form-group-sm textarea.form-control, .form-group-sm select[multiple].form-control { height: auto; }
+.form-group-sm .form-control-static { height: 33px; padding: 5px 10px; font-size: 14px; line-height: 1.5; min-height: 46px; }
 
-select.input-lg, .input-group-lg > select.form-control, .input-group-lg > select.input-group-addon, .input-group-lg > .input-group-btn > select.btn, .form-group-lg .form-control { height: 49px; line-height: 49px; }
+.input-lg, .input-group-lg > .form-control, .input-group-lg > .input-group-addon, .input-group-lg > .input-group-btn > .btn { height: 49px; padding: 10px 16px; font-size: 20px; line-height: 1.33; border-radius: 6px; }
 
-textarea.input-lg, .input-group-lg > textarea.form-control, .input-group-lg > textarea.input-group-addon, .input-group-lg > .input-group-btn > textarea.btn, .form-group-lg .form-control, select[multiple].input-lg, .input-group-lg > select[multiple].form-control, .input-group-lg > select[multiple].input-group-addon, .input-group-lg > .input-group-btn > select[multiple].btn, .form-group-lg .form-control { height: auto; }
+select.input-lg, .input-group-lg > select.form-control, .input-group-lg > select.input-group-addon, .input-group-lg > .input-group-btn > select.btn { height: 49px; line-height: 49px; }
+
+textarea.input-lg, .input-group-lg > textarea.form-control, .input-group-lg > textarea.input-group-addon, .input-group-lg > .input-group-btn > textarea.btn, select[multiple].input-lg, .input-group-lg > select[multiple].form-control, .input-group-lg > select[multiple].input-group-addon, .input-group-lg > .input-group-btn > select[multiple].btn { height: auto; }
+
+.form-group-lg .form-control { height: 49px; padding: 10px 16px; font-size: 20px; line-height: 1.33; border-radius: 6px; }
+.form-group-lg select.form-control { height: 49px; line-height: 49px; }
+.form-group-lg textarea.form-control, .form-group-lg select[multiple].form-control { height: auto; }
+.form-group-lg .form-control-static { height: 49px; padding: 10px 16px; font-size: 20px; line-height: 1.33; min-height: 52px; }
 
 .has-feedback { position: relative; }
 .has-feedback .form-control { padding-right: 57.5px; }
@@ -1200,8 +1337,8 @@ input[type="submit"].btn-block, input[type="reset"].btn-block, input[type="butto
 .fade { opacity: 0; -webkit-transition: opacity 0.15s linear; -o-transition: opacity 0.15s linear; transition: opacity 0.15s linear; }
 .fade.in { opacity: 1; }
 
-.collapse { display: none; visibility: hidden; }
-.collapse.in { display: block; visibility: visible; }
+.collapse { display: none; }
+.collapse.in { display: block; }
 
 tr.collapse.in { display: table-row; }
 
@@ -1209,9 +1346,9 @@ tbody.collapse.in { display: table-row-group; }
 
 .collapsing { position: relative; height: 0; overflow: hidden; -webkit-transition-property: height, visibility; transition-property: height, visibility; -webkit-transition-duration: 0.35s; transition-duration: 0.35s; -webkit-transition-timing-function: ease; transition-timing-function: ease; }
 
-.caret { display: inline-block; width: 0; height: 0; margin-left: 2px; vertical-align: middle; border-top: 4px solid; border-right: 4px solid transparent; border-left: 4px solid transparent; }
+.caret { display: inline-block; width: 0; height: 0; margin-left: 2px; vertical-align: middle; border-top: 4px dashed; border-right: 4px solid transparent; border-left: 4px solid transparent; }
 
-.dropdown { position: relative; }
+.dropup, .dropdown { position: relative; }
 
 .dropdown-toggle:focus { outline: 0; }
 
@@ -1241,7 +1378,7 @@ tbody.collapse.in { display: table-row-group; }
 .pull-right > .dropdown-menu { right: 0; left: auto; }
 
 .dropup .caret, .navbar-fixed-bottom .dropdown .caret { border-top: 0; border-bottom: 4px solid; content: ""; }
-.dropup .dropdown-menu, .navbar-fixed-bottom .dropdown .dropdown-menu { top: auto; bottom: 100%; margin-bottom: 1px; }
+.dropup .dropdown-menu, .navbar-fixed-bottom .dropdown .dropdown-menu { top: auto; bottom: 100%; margin-bottom: 2px; }
 
 @media (min-width: 768px) { .navbar-right .dropdown-menu { right: 0; left: auto; }
   .navbar-right .dropdown-menu-left { left: 0; right: auto; } }
@@ -1268,9 +1405,9 @@ tbody.collapse.in { display: table-row-group; }
 
 .btn-group > .btn-group:not(:first-child):not(:last-child) > .btn { border-radius: 0; }
 
-.btn-group > .btn-group:first-child > .btn:last-child, .btn-group > .btn-group:first-child > .dropdown-toggle { border-bottom-right-radius: 0; border-top-right-radius: 0; }
+.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child, .btn-group > .btn-group:first-child:not(:last-child) > .dropdown-toggle { border-bottom-right-radius: 0; border-top-right-radius: 0; }
 
-.btn-group > .btn-group:last-child > .btn:first-child { border-bottom-left-radius: 0; border-top-left-radius: 0; }
+.btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child { border-bottom-left-radius: 0; border-top-left-radius: 0; }
 
 .btn-group .dropdown-toggle:active, .btn-group.open .dropdown-toggle { outline: 0; }
 
@@ -1378,8 +1515,8 @@ tbody.collapse.in { display: table-row-group; }
 @media (min-width: 768px) { .nav-tabs-justified > li > a, .nav-tabs.nav-justified > li > a { border-bottom: 1px solid #ddd; border-radius: 4px 4px 0 0; }
   .nav-tabs-justified > .active > a, .nav-tabs.nav-justified > .active > a, .nav-tabs-justified > .active > a:hover, .nav-tabs.nav-justified > .active > a:hover, .nav-tabs-justified > .active > a:focus, .nav-tabs.nav-justified > .active > a:focus { border-bottom-color: #ffffff; } }
 
-.tab-content > .tab-pane { display: none; visibility: hidden; }
-.tab-content > .active { display: block; visibility: visible; }
+.tab-content > .tab-pane { display: none; }
+.tab-content > .active { display: block; }
 
 .nav-tabs .dropdown-menu { margin-top: -1px; border-top-right-radius: 0; border-top-left-radius: 0; }
 
@@ -1397,7 +1534,7 @@ tbody.collapse.in { display: table-row-group; }
 .navbar-collapse:after { clear: both; }
 .navbar-collapse.in { overflow-y: auto; }
 @media (min-width: 768px) { .navbar-collapse { width: auto; border-top: 0; box-shadow: none; }
-  .navbar-collapse.collapse { display: block !important; visibility: visible !important; height: auto !important; padding-bottom: 0; overflow: visible !important; }
+  .navbar-collapse.collapse { display: block !important; height: auto !important; padding-bottom: 0; overflow: visible !important; }
   .navbar-collapse.in { overflow-y: visible; }
   .navbar-fixed-top .navbar-collapse, .navbar-static-top .navbar-collapse, .navbar-fixed-bottom .navbar-collapse { padding-left: 0; padding-right: 0; } }
 
@@ -1456,7 +1593,7 @@ tbody.collapse.in { display: table-row-group; }
 
 .navbar-nav > li > .dropdown-menu { margin-top: 0; border-top-right-radius: 0; border-top-left-radius: 0; }
 
-.navbar-fixed-bottom .navbar-nav > li > .dropdown-menu { border-top-right-radius: 4px; border-top-left-radius: 4px; border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+.navbar-fixed-bottom .navbar-nav > li > .dropdown-menu { margin-bottom: 0; border-top-right-radius: 4px; border-top-left-radius: 4px; border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
 
 .navbar-btn { margin-top: 2px; margin-bottom: 2px; }
 .navbar-btn.btn-sm, .btn-group-sm > .navbar-btn.btn { margin-top: 8.5px; margin-bottom: 8.5px; }
@@ -1575,7 +1712,7 @@ a.label:hover, a.label:focus { color: #fff; text-decoration: none; cursor: point
 .badge { display: inline-block; min-width: 10px; padding: 3px 7px; font-size: 14px; font-weight: bold; color: #fff; line-height: 1; vertical-align: baseline; white-space: nowrap; text-align: center; background-color: #999999; border-radius: 10px; }
 .badge:empty { display: none; }
 .btn .badge { position: relative; top: -1px; }
-.btn-xs .badge, .btn-group-xs > .btn .badge { top: 0; padding: 1px 5px; }
+.btn-xs .badge, .btn-group-xs > .btn .badge, .btn-group-xs > .btn .badge { top: 0; padding: 1px 5px; }
 .list-group-item.active > .badge, .nav-pills > .active > a > .badge { color: #0A77BD; background-color: #fff; }
 .list-group-item > .badge { float: right; }
 .list-group-item > .badge + .badge { margin-right: 5px; }
@@ -1651,6 +1788,12 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active { border-color: #0A77BD
 .media { margin-top: 15px; }
 .media:first-child { margin-top: 0; }
 
+.media, .media-body { zoom: 1; overflow: hidden; }
+
+.media-body { width: 10000px; }
+
+.media-object { display: block; }
+
 .media-right, .media > .pull-right { padding-left: 10px; }
 
 .media-left, .media > .pull-left { padding-right: 10px; }
@@ -1724,7 +1867,7 @@ a.list-group-item-danger.active, a.list-group-item-danger.active:hover, a.list-g
 .panel-heading > .dropdown .dropdown-toggle { color: inherit; }
 
 .panel-title { margin-top: 0; margin-bottom: 0; font-size: 18px; color: inherit; }
-.panel-title > a { color: inherit; }
+.panel-title > a, .panel-title > small, .panel-title > .small, .panel-title > small > a, .panel-title > .small > a { color: inherit; }
 
 .panel-footer { padding: 10px 15px; background-color: #f5f5f5; border-top: 1px solid #ddd; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; }
 
@@ -1802,8 +1945,10 @@ a.list-group-item-danger.active, a.list-group-item-danger.active:hover, a.list-g
 
 .embed-responsive { position: relative; display: block; height: 0; padding: 0; overflow: hidden; }
 .embed-responsive .embed-responsive-item, .embed-responsive iframe, .embed-responsive embed, .embed-responsive object, .embed-responsive video { position: absolute; top: 0; left: 0; bottom: 0; height: 100%; width: 100%; border: 0; }
-.embed-responsive.embed-responsive-16by9 { padding-bottom: 56.25%; }
-.embed-responsive.embed-responsive-4by3 { padding-bottom: 75%; }
+
+.embed-responsive-16by9 { padding-bottom: 56.25%; }
+
+.embed-responsive-4by3 { padding-bottom: 75%; }
 
 .well { min-height: 20px; padding: 19px; margin-bottom: 20px; background-color: #f5f5f5; border: 1px solid #e3e3e3; border-radius: 4px; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); }
 .well blockquote { border-color: #ddd; border-color: rgba(0, 0, 0, 0.15); }
@@ -1829,7 +1974,7 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 .modal-content { position: relative; background-color: #fff; border: 1px solid #999; border: 1px solid rgba(0, 0, 0, 0.2); border-radius: 6px; -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5); box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5); background-clip: padding-box; outline: 0; }
 
-.modal-backdrop { position: absolute; top: 0; right: 0; left: 0; background-color: #000; }
+.modal-backdrop { position: fixed; top: 0; right: 0; bottom: 0; left: 0; z-index: 1040; background-color: #000; }
 .modal-backdrop.fade { opacity: 0; filter: alpha(opacity=0); }
 .modal-backdrop.in { opacity: 0.5; filter: alpha(opacity=50); }
 
@@ -1854,7 +1999,7 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
   .modal-content { -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); }
   .modal-sm { width: 300px; } }
 @media (min-width: 992px) { .modal-lg { width: 900px; } }
-.tooltip { position: absolute; z-index: 1030; display: block; visibility: visible; font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif; font-size: 14px; font-weight: normal; line-height: 1.4; opacity: 0; filter: alpha(opacity=0); }
+.tooltip { position: absolute; z-index: 1030; display: block; font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif; font-size: 14px; font-weight: normal; line-height: 1.4; opacity: 0; filter: alpha(opacity=0); }
 .tooltip.in { opacity: 0.9; filter: alpha(opacity=90); }
 .tooltip.top { margin-top: -3px; padding: 5px 0; }
 .tooltip.right { margin-left: 3px; padding: 0 5px; }
@@ -1904,10 +2049,10 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 .carousel-inner { position: relative; overflow: hidden; width: 100%; }
 .carousel-inner > .item { display: none; position: relative; -webkit-transition: 0.6s ease-in-out left; -o-transition: 0.6s ease-in-out left; transition: 0.6s ease-in-out left; }
 .carousel-inner > .item > img, .carousel-inner > .item > a > img { display: block; max-width: 100%; height: auto; line-height: 1; }
-@media all and (transform-3d), (-webkit-transform-3d) { .carousel-inner > .item { transition: transform .6s ease-in-out; backface-visibility: hidden; perspective: 1000; }
-  .carousel-inner > .item.next, .carousel-inner > .item.active.right { transform: translate3d(100%, 0, 0); left: 0; }
-  .carousel-inner > .item.prev, .carousel-inner > .item.active.left { transform: translate3d(-100%, 0, 0); left: 0; }
-  .carousel-inner > .item.next.left, .carousel-inner > .item.prev.right, .carousel-inner > .item.active { transform: translate3d(0, 0, 0); left: 0; } }
+@media all and (transform-3d), (-webkit-transform-3d) { .carousel-inner > .item { -webkit-transition: -webkit-transform 0.6s ease-in-out; -moz-transition: -moz-transform 0.6s ease-in-out; -o-transition: -o-transform 0.6s ease-in-out; transition: transform 0.6s ease-in-out; -webkit-backface-visibility: hidden; -moz-backface-visibility: hidden; backface-visibility: hidden; -webkit-perspective: 1000; -moz-perspective: 1000; perspective: 1000; }
+  .carousel-inner > .item.next, .carousel-inner > .item.active.right { -webkit-transform: translate3d(100%, 0, 0); transform: translate3d(100%, 0, 0); left: 0; }
+  .carousel-inner > .item.prev, .carousel-inner > .item.active.left { -webkit-transform: translate3d(-100%, 0, 0); transform: translate3d(-100%, 0, 0); left: 0; }
+  .carousel-inner > .item.next.left, .carousel-inner > .item.prev.right, .carousel-inner > .item.active { -webkit-transform: translate3d(0, 0, 0); transform: translate3d(0, 0, 0); left: 0; } }
 .carousel-inner > .active, .carousel-inner > .next, .carousel-inner > .prev { display: block; }
 .carousel-inner > .active { left: 0; }
 .carousel-inner > .next, .carousel-inner > .prev { position: absolute; top: 0; width: 100%; }
@@ -1924,7 +2069,7 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 .carousel-control .icon-prev, .carousel-control .icon-next, .carousel-control .glyphicon-chevron-left, .carousel-control .glyphicon-chevron-right { position: absolute; top: 50%; z-index: 5; display: inline-block; }
 .carousel-control .icon-prev, .carousel-control .glyphicon-chevron-left { left: 50%; margin-left: -10px; }
 .carousel-control .icon-next, .carousel-control .glyphicon-chevron-right { right: 50%; margin-right: -10px; }
-.carousel-control .icon-prev, .carousel-control .icon-next { width: 20px; height: 20px; margin-top: -10px; font-family: serif; }
+.carousel-control .icon-prev, .carousel-control .icon-next { width: 20px; height: 20px; margin-top: -10px; line-height: 1; font-family: serif; }
 .carousel-control .icon-prev:before { content: '\2039'; }
 .carousel-control .icon-next:before { content: '\203a'; }
 
@@ -1957,12 +2102,18 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 .text-hide { font: 0/0 a; color: transparent; text-shadow: none; background-color: transparent; border: 0; }
 
-.hidden { display: none !important; visibility: hidden !important; }
+.hidden { display: none !important; }
 
 .affix { position: fixed; }
 
 @-ms-viewport { width: device-width; }
-.visible-xs, .visible-sm, .visible-md, .visible-lg { display: none !important; }
+.visible-xs { display: none !important; }
+
+.visible-sm { display: none !important; }
+
+.visible-md { display: none !important; }
+
+.visible-lg { display: none !important; }
 
 .visible-xs-block, .visible-xs-inline, .visible-xs-inline-block, .visible-sm-block, .visible-sm-inline, .visible-sm-inline-block, .visible-md-block, .visible-md-inline, .visible-md-inline-block, .visible-lg-block, .visible-lg-inline, .visible-lg-inline-block { display: none !important; }
 
@@ -2027,15 +2178,15 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 @media print { .hidden-print { display: none !important; } }
 /*!
- *  Font Awesome 4.2.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  Font Awesome 4.3.0 by @davegandy - http://fontawesome.io - @fontawesome
  *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
  */
 /* FONT PATH -------------------------- */
-@font-face { font-family: 'FontAwesome'; src: url("../fonts/fontawesome-webfont.eot?v=4.2.0"); src: url("../fonts/fontawesome-webfont.eot?#iefix&v=4.2.0") format("embedded-opentype"), url("../fonts/fontawesome-webfont.woff?v=4.2.0") format("woff"), url("../fonts/fontawesome-webfont.ttf?v=4.2.0") format("truetype"), url("../fonts/fontawesome-webfont.svg?v=4.2.0#fontawesomeregular") format("svg"); font-weight: normal; font-style: normal; }
-.fa { display: inline-block; font: normal normal normal 14px/1 FontAwesome; font-size: inherit; text-rendering: auto; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+@font-face { font-family: 'FontAwesome'; src: url("../fonts/fontawesome-webfont.eot?v=4.3.0"); src: url("../fonts/fontawesome-webfont.eot?#iefix&v=4.3.0") format("embedded-opentype"), url("../fonts/fontawesome-webfont.woff2?v=4.3.0") format("woff2"), url("../fonts/fontawesome-webfont.woff?v=4.3.0") format("woff"), url("../fonts/fontawesome-webfont.ttf?v=4.3.0") format("truetype"), url("../fonts/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular") format("svg"); font-weight: normal; font-style: normal; }
+.fa { display: inline-block; font: normal normal normal 14px/1 FontAwesome; font-size: inherit; text-rendering: auto; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; transform: translate(0, 0); }
 
 /* makes the font 33% larger relative to the icon container */
-.fa-lg { font-size: 1.3333333333em; line-height: 0.75em; vertical-align: -15%; }
+.fa-lg { font-size: 1.33333333em; line-height: 0.75em; vertical-align: -15%; }
 
 .fa-2x { font-size: 2em; }
 
@@ -2045,13 +2196,13 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 .fa-5x { font-size: 5em; }
 
-.fa-fw { width: 1.2857142857em; text-align: center; }
+.fa-fw { width: 1.28571429em; text-align: center; }
 
-.fa-ul { padding-left: 0; margin-left: 2.1428571429em; list-style-type: none; }
+.fa-ul { padding-left: 0; margin-left: 2.14285714em; list-style-type: none; }
 .fa-ul > li { position: relative; }
 
-.fa-li { position: absolute; left: -2.1428571429em; width: 2.1428571429em; top: 0.1428571429em; text-align: center; }
-.fa-li.fa-lg { left: -1.8571428571em; }
+.fa-li { position: absolute; left: -2.14285714em; width: 2.14285714em; top: 0.14285714em; text-align: center; }
+.fa-li.fa-lg { left: -1.85714286em; }
 
 .fa-border { padding: .2em .25em .15em; border: solid 0.08em #eee; border-radius: .1em; }
 
@@ -2063,6 +2214,8 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 .fa.pull-right { margin-left: .3em; }
 
 .fa-spin { -webkit-animation: fa-spin 2s infinite linear; animation: fa-spin 2s infinite linear; }
+
+.fa-pulse { -webkit-animation: fa-spin 1s infinite steps(8); animation: fa-spin 1s infinite steps(8); }
 
 @-webkit-keyframes fa-spin { 0% { -webkit-transform: rotate(0deg); transform: rotate(0deg); }
   100% { -webkit-transform: rotate(359deg); transform: rotate(359deg); } }
@@ -2381,7 +2534,7 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 .fa-twitter:before { content: ""; }
 
-.fa-facebook:before { content: ""; }
+.fa-facebook-f:before, .fa-facebook:before { content: ""; }
 
 .fa-github:before { content: ""; }
 
@@ -2791,7 +2944,7 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 .fa-male:before { content: ""; }
 
-.fa-gittip:before { content: ""; }
+.fa-gittip:before, .fa-gratipay:before { content: ""; }
 
 .fa-sun-o:before { content: ""; }
 
@@ -2955,7 +3108,7 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 .fa-history:before { content: ""; }
 
-.fa-circle-thin:before { content: ""; }
+.fa-genderless:before, .fa-circle-thin:before { content: ""; }
 
 .fa-header:before { content: ""; }
 
@@ -3048,6 +3201,86 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 .fa-shekel:before, .fa-sheqel:before, .fa-ils:before { content: ""; }
 
 .fa-meanpath:before { content: ""; }
+
+.fa-buysellads:before { content: ""; }
+
+.fa-connectdevelop:before { content: ""; }
+
+.fa-dashcube:before { content: ""; }
+
+.fa-forumbee:before { content: ""; }
+
+.fa-leanpub:before { content: ""; }
+
+.fa-sellsy:before { content: ""; }
+
+.fa-shirtsinbulk:before { content: ""; }
+
+.fa-simplybuilt:before { content: ""; }
+
+.fa-skyatlas:before { content: ""; }
+
+.fa-cart-plus:before { content: ""; }
+
+.fa-cart-arrow-down:before { content: ""; }
+
+.fa-diamond:before { content: ""; }
+
+.fa-ship:before { content: ""; }
+
+.fa-user-secret:before { content: ""; }
+
+.fa-motorcycle:before { content: ""; }
+
+.fa-street-view:before { content: ""; }
+
+.fa-heartbeat:before { content: ""; }
+
+.fa-venus:before { content: ""; }
+
+.fa-mars:before { content: ""; }
+
+.fa-mercury:before { content: ""; }
+
+.fa-transgender:before { content: ""; }
+
+.fa-transgender-alt:before { content: ""; }
+
+.fa-venus-double:before { content: ""; }
+
+.fa-mars-double:before { content: ""; }
+
+.fa-venus-mars:before { content: ""; }
+
+.fa-mars-stroke:before { content: ""; }
+
+.fa-mars-stroke-v:before { content: ""; }
+
+.fa-mars-stroke-h:before { content: ""; }
+
+.fa-neuter:before { content: ""; }
+
+.fa-facebook-official:before { content: ""; }
+
+.fa-pinterest-p:before { content: ""; }
+
+.fa-whatsapp:before { content: ""; }
+
+.fa-server:before { content: ""; }
+
+.fa-user-plus:before { content: ""; }
+
+.fa-user-times:before { content: ""; }
+
+.fa-hotel:before, .fa-bed:before { content: ""; }
+
+.fa-viacoin:before { content: ""; }
+
+.fa-train:before { content: ""; }
+
+.fa-subway:before { content: ""; }
+
+.fa-medium:before { content: ""; }
 
 .container .container, .container .container-fluid { width: auto; margin-left: -15px; margin-right: -15px; }
 
@@ -3189,7 +3422,7 @@ form .description { margin: 2px 0; color: #555555; }
 fieldset legend { float: left; line-height: 1em; margin: 0; }
 fieldset .panel-body { clear: both; }
 
-html.js input.form-autocomplete { background: url('../images/throbber.gif?1435352840') no-repeat right 8px #fff !important; }
+html.js input.form-autocomplete { background: url('../images/throbber.gif?1447440358') no-repeat right 8px #fff !important; }
 html.js input.throbbing { background-position: right -122px !important; }
 html.js fieldset.collapsed { height: auto; border-left-width: 1px; border-right-width: 1px; }
 
@@ -3590,8 +3823,9 @@ div.horizontal-tabs { border: none; }
 .field-group-table-description { color: #555555; display: block; padding: 8px 10px 8px 40px; position: relative; }
 .field-group-table-description .icon-info-sign:before { color: #999999; content: "\f05a"; font-family: "FontAwesome"; font-size: 2.5em; font-style: normal; height: 30px; left: 0; margin: 10px 15px 0 0; padding: 6px 0; position: absolute; top: -6px; width: 30px; }
 
-.node-type-group .radix-layouts-content .pane-content { padding: 0; }
 .node-type-group .horizontal-tabs { margin: 0; }
+
+.group-owner-message { margin-bottom: 20px; }
 
 .field-type-text-with-summary { padding: 0; }
 

--- a/templates/node/node--group.tpl.php
+++ b/templates/node/node--group.tpl.php
@@ -32,7 +32,7 @@
         ?>
       </p>
     </div>
-    <div class="button"><?php print render($content["og_count_entity_view_1"]); ?></div> 
+    <div class="button"><?php print render($content["og_count_entity_view_1"]); ?></div>
   </article>
 
 <?php else: ?>


### PR DESCRIPTION
## Acceptance test
- [x] Built a dkan instance using the branch remove_tab_groups_and_add_link_member_list_907 from dkan_dataset
- [x] Use this branch of nuboot radix
- [x] Group info should display the members count with the following appearance:

<img width="1228" alt="screen shot 2015-11-13 at 6 26 51 pm" src="https://cloud.githubusercontent.com/assets/381224/11158070/654b5a68-8a34-11e5-80b8-ae8ced2ff0bb.png">
