### PR TITLE
Get settings only from from nuboot radix

### DIFF
--- a/theme-settings.php
+++ b/theme-settings.php
@@ -19,7 +19,7 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
   );
 
   // Copyright.
-  $copyright = theme_get_setting('copyright');
+  $copyright = theme_get_setting('copyright', 'nuboot_radix');
   $form['nuboot_radix_theme_settings']['copyright'] = array(
     '#title' => t('Copyright'),
     '#type' => 'text_format',
@@ -37,13 +37,13 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
   $form['hero']['hero_file'] = array(
     '#type' => 'managed_file',
     '#title' => t('Upload a new photo for the hero section background'),
-    '#description' => t('<p>The hero unit is the large featured area located on the front page. 
-      This theme supplies a default background image for this area. You may upload a different 
+    '#description' => t('<p>The hero unit is the large featured area located on the front page.
+      This theme supplies a default background image for this area. You may upload a different
       photo here and it will replace the default background image.</p><p>Max. file size: 2 MB
       <br>Recommended pixel size: 1920 x 400<br>Allowed extensions: .png .jpg .jpeg</p>'),
     '#required' => FALSE,
     '#upload_location' => file_default_scheme() . '://theme/backgrounds/',
-    '#default_value' => theme_get_setting('hero_file'), 
+    '#default_value' => theme_get_setting('hero_file', 'nuboot_radix'),
     '#upload_validators' => array(
       'file_validate_extensions' => array('gif png jpg jpeg'),
     ),
@@ -55,7 +55,7 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
     '#title' => t('Solid color option'),
     '#description' => t('<p>Enter a hex value here to use a solid background color rather than an image in the hero unit. Make sure the image field above is empty.'),
     '#required' => FALSE,
-    '#default_value' => theme_get_setting('background_option'),
+    '#default_value' => theme_get_setting('background_option', 'nuboot_radix'),
     '#element_validate' => array('_background_option_setting'),
   );
 
@@ -66,7 +66,7 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
     '#description' => t('<p>Be sure to also add a .png version of your logo with the <em>Upload logo image</em> field above for older browsers that do not support .svg files. Both files should have the same name, only the suffix should change (i.e. logo.png & logo.svg).</p>'),
     '#required' => FALSE,
     '#upload_location' => file_default_scheme() . '://',
-    '#default_value' => theme_get_setting('svg_logo'), 
+    '#default_value' => theme_get_setting('svg_logo', 'nuboot_radix'),
     '#upload_validators' => array(
       'file_validate_extensions' => array('svg'),
     ),


### PR DESCRIPTION
**A brief explanation**

theme_get_setting retrieves the setting from the default theme if not key is provided as second parameter. This ties all the theme settings forms in sub themes of nuboot radix to the default theme. 

Then changing values in any theme settings forms that inherit from nuboot_radix will change those values only in the default theme and not in the corresponding sub theme.
### Acceptance test
- [ ] Acceptance test in NuCivic/nucivic_data_sandbox#33 passes
- [ ] This change shouldn't break anything in the theme edit form for out-of-box DKAN using nuboot_radix theme.
