### PR TITLE
CSS tweaks (Datasets page)

### DIFF
--- a/assets/sass/partials/_panel.scss
+++ b/assets/sass/partials/_panel.scss
@@ -66,10 +66,14 @@
 		padding:0;
 	}
 	.pane-content {
-		@include popblock;
 		@include border-radius(0);
 		@include box-shadow(none);
 		margin-bottom: 3em;
+		padding:0px;
+		.pane-content {
+			margin: 0;
+			padding: 15px;
+		}
 	}
 	.pane-page-breadcrumb {
 		@include block-plain;

--- a/assets/sass/partials/_panel.scss
+++ b/assets/sass/partials/_panel.scss
@@ -44,6 +44,7 @@
 	}
 	.pane-block {
 		@include popblock;
+		@include box-shadow(0 0 1px rgba(0, 0, 0, 0.3));
 	}
 	// facet blocks.
 	div[class*="pane-facetapi"] .pane-content,
@@ -66,7 +67,8 @@
 	}
 	.pane-content {
 		@include popblock;
-		padding: 20px;
+		@include border-radius(0);
+		@include box-shadow(none);
 		margin-bottom: 3em;
 	}
 	.pane-page-breadcrumb {


### PR DESCRIPTION
ref https://jira.govdelivery.com/browse/CIVIC-205
### Acceptance
- As a user, when I access "/dataset" I should not see box-shadow and padding around main content pane
- As a user, when I access "/dataset" I should see 1px box-shadow around sidebar blocks
