### PR TITLE
Fix hero image gettings deleted

### DIFF
--- a/theme-settings.php
+++ b/theme-settings.php
@@ -71,6 +71,9 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
       'file_validate_extensions' => array('svg'),
     ),
   );
+  
+  $form['#submit'][] = 'nuboot_radix_hero_system_theme_settings_form_submit';
+
   // Return the additional form widgets.
   return $form;
 }
@@ -96,5 +99,23 @@ function _background_option_setting($element, &$form, &$form_state) {
     else {
       form_error($element, t('Must be a valid hexadecimal CSS color value.'));
     }
+  }
+}
+
+/**
+ * Submit function for theme settings form.
+ */
+function nuboot_radix_hero_system_theme_settings_form_submit(&$form, &$form_state) {
+  if ($form_state['values']['hero_file']) {
+    $fid = $form_state['values']['hero_file'];
+    $file = file_load($fid);
+    $file->status = FILE_STATUS_PERMANENT;
+    file_save($file);
+  }
+  if ($form_state['values']['svg_logo']) {
+    $fid = $form_state['values']['svg_logo'];
+    $file = file_load($fid);
+    $file->status = FILE_STATUS_PERMANENT;
+    file_save($file);
   }
 }

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -108,18 +108,18 @@ function _background_option_setting($element, &$form, &$form_state) {
 function nuboot_radix_hero_system_theme_settings_form_submit(&$form, &$form_state) {
   if ($form_state['values']['hero_file']) {
     $fid = $form_state['values']['hero_file'];
-    _nuboo_radix_file_set_permanent($fid);
+    _nuboot_radix_file_set_permanent($fid);
   }
   if ($form_state['values']['svg_logo']) {
     $fid = $form_state['values']['svg_logo'];
-    _nuboo_radix_file_set_permanent($fid);
+    _nuboot_radix_file_set_permanent($fid);
   }
 }
 
 /**
  *  Sets file to FILE_STATUS_PERMANENT so it won't be erased by cron.
  */
-function _nuboo_radix_file_set_permanent($fid) {
+function _nuboot_radix_file_set_permanent($fid) {
   $file = file_load($fid);
   $file->status = FILE_STATUS_PERMANENT;
   file_save($file);

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -108,11 +108,11 @@ function _background_option_setting($element, &$form, &$form_state) {
 function nuboot_radix_hero_system_theme_settings_form_submit(&$form, &$form_state) {
   if ($form_state['values']['hero_file']) {
     $fid = $form_state['values']['hero_file'];
-    _nuboo_radix_file_set_permanent($fid)
+    _nuboo_radix_file_set_permanent($fid);
   }
   if ($form_state['values']['svg_logo']) {
     $fid = $form_state['values']['svg_logo'];
-    _nuboo_radix_file_set_permanent($fid)
+    _nuboo_radix_file_set_permanent($fid);
   }
 }
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -108,14 +108,19 @@ function _background_option_setting($element, &$form, &$form_state) {
 function nuboot_radix_hero_system_theme_settings_form_submit(&$form, &$form_state) {
   if ($form_state['values']['hero_file']) {
     $fid = $form_state['values']['hero_file'];
-    $file = file_load($fid);
-    $file->status = FILE_STATUS_PERMANENT;
-    file_save($file);
+    _nuboo_radix_file_set_permanent($fid)
   }
   if ($form_state['values']['svg_logo']) {
     $fid = $form_state['values']['svg_logo'];
-    $file = file_load($fid);
-    $file->status = FILE_STATUS_PERMANENT;
-    file_save($file);
+    _nuboo_radix_file_set_permanent($fid)
   }
+}
+
+/**
+ *  Sets file to FILE_STATUS_PERMANENT so it won't be erased by cron.
+ */
+function _nuboo_radix_file_set_permanent($fid) {
+  $file = file_load($fid);
+  $file->status = FILE_STATUS_PERMANENT;
+  file_save($file);
 }


### PR DESCRIPTION
## Description

This makes sure that the hero and svg images are saved properly with a status = 1 in the file_managed table.
## Acceptance Criteria
- [ ] Upload new hero image on 7.x-1.x branch.
- [ ] Image should have a status of 0 in file_managed
- [ ] Upload new hero image on hero_image_fix branch.
- [ ] Image should have a status of 1 in file_managed
