### PR TITLE
Update file insert function to remove special characters from file names

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.x
 --------------------------
-- Add managed file support to logo and hero image, plus support for spaces in filenames, which were broken.
+- Add managed file support to logo and hero image
+- Add check on filenames to remove spaces and special characters that can break functionality.
 - Make date facets consistant with other facets styling
 - Upgraded to use Radix 3.3. See README.md for updated use instructions
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -42,7 +42,7 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
       photo here and it will replace the default background image.</p><p>Max. file size: 2 MB
       <br>Recommended pixel size: 1920 x 400<br>Allowed extensions: .png .jpg .jpeg</p>'),
     '#required' => FALSE,
-    '#upload_location' => file_default_scheme() . '://theme/backgrounds/',
+    '#upload_location' => file_default_scheme() . '://theme/',
     '#default_value' => !empty($hero) ? $hero : NULL,
     '#upload_validators' => array(
       'file_validate_extensions' => array('gif png jpg jpeg'),
@@ -123,7 +123,6 @@ function _nuboot_radix_file_set_permanent($fid) {
   $file = file_load($fid);
   $file->status = FILE_STATUS_PERMANENT;
   file_save($file);
-  // https://www.drupal.org/node/979158. 
   file_usage_add($file, 'theme', 'file', $fid);
   nuboot_file_insert($file);
 }
@@ -133,6 +132,7 @@ function _nuboot_radix_file_set_permanent($fid) {
  */
 function nuboot_file_insert($file) {
   $file->filename = str_replace(' ', '-', $file->filename);
-  $hash = 'public://' . $file->filename;
-   file_move($file, $hash, 'FILE_EXIST_REPLACE');
+  $file->filename = preg_replace("/[^\-.a-zA-Z0-9]/", "", $file->filename);
+  $name = 'public://' . $file->filename;
+  file_move($file, $name, 'FILE_EXIST_REPLACE');
 }


### PR DESCRIPTION
## Issue

~~Still getting `Notice: Undefined index: #field_name` errors, so I am removing the upload location lint that  put the file in a sites/default/files/theme directory. It seems sometimes the directory can not be created for some reason and the upload fails.~~

**UPDATE** - I think the field_name error is simply a docker permission issue, restoring the upload location lines.

Also adding an extra string function to clean up file names if they contain strange characters.

To test, name a file like this: üiaj af1 2_3 7412~!@#$%^&*()=+][{}.jpg
