### PR TITLE
Update the search result template

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@
 - Add managed file support to logo and hero image, plus support for spaces in filenames, which were broken.
 - Make date facets consistant with other facets styling
 - Upgraded to use Radix 3.3. See README.md for updated use instructions
+- Fix node--search-result.tpl.php file to check the $group_list variable before printing markup
 
 7.x-1.11 2016-02-02
 --------------------------

--- a/templates/node/node--search-result.tpl.php
+++ b/templates/node/node--search-result.tpl.php
@@ -12,8 +12,9 @@
   </div>
   <div class="col-md-10 col-lg-11 col-xs-10 search-result search-result-<?php print $type ?>">
     <h2 class="node-title"><a href="/<?php print $node_url ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
-    <?php print render($topics) ?>
-    <div class="group-membership"><?php print $group_list ?></div>
+    <?php if(!empty($group_list)): ?>
+      <div class="group-membership"><?php print $group_list ?></div>
+    <?php endif; ?>
     <?php print render($content['field_topic']); ?>
     <ul class="dataset-list"><?php print $dataset_list ?></ul>
     <?php if(!empty($body)): ?>


### PR DESCRIPTION
## Issue

The search results template is not checking if the $group_list variable is empty before printing the markup.
![screenshot_4_4_16__4_10_pm-2](https://cloud.githubusercontent.com/assets/314172/14263442/3f98258c-fa80-11e5-8c82-d6a014964dee.png)
## Acceptance Criteria

When viewing search results I should not see the group icon below content that is not part of a group.
