### PR TITLE
Hide iframe when more than a resource type is present

### DIFF
--- a/assets/css/nuboot_radix.style.css
+++ b/assets/css/nuboot_radix.style.css
@@ -9494,7 +9494,7 @@ ul.action-links {
     .node-resource-form .horizontal-tabs ul.horizontal-tabs-list li.selected {
       border: 0;
       background-color: transparent;
-      min-width: 10em; }
+      min-width: 4em; }
       .node-resource-form .horizontal-tabs ul.horizontal-tabs-list li a:hover,
       .node-resource-form .horizontal-tabs ul.horizontal-tabs-list li.selected a:hover {
         background: transparent; }
@@ -9505,7 +9505,7 @@ ul.action-links {
         text-indent: -9999px;
         width: 16px;
         height: 16px;
-        margin: 0 0 0 28px;
+        left: 50%;
         clip: auto; }
       .node-resource-form .horizontal-tabs ul.horizontal-tabs-list li.horizontal-tab-button-1 .summary,
       .node-resource-form .horizontal-tabs ul.horizontal-tabs-list li.horizontal-tab-button-2 .summary,

--- a/scss/components/_node.scss
+++ b/scss/components/_node.scss
@@ -34,7 +34,7 @@
     li.selected {
       border: 0;
       background-color: transparent;
-      min-width: 10em;
+      min-width: 4em;
       a:hover {
         background:transparent;
       }
@@ -44,7 +44,7 @@
         text-indent: -9999px;
         width: 16px;
         height: 16px;
-        margin: 0 0 0 28px;
+        left: 50%;
         clip: auto;
       }
       &.horizontal-tab-button-1 .summary,

--- a/template.php
+++ b/template.php
@@ -13,6 +13,35 @@ require_once dirname(__FILE__) . '/includes/panel.inc';
 require_once dirname(__FILE__) . '/includes/user.inc';
 require_once dirname(__FILE__) . '/includes/view.inc';
 
+/*
+ * Hides the link to API (URL) iframe when either the field
+ * upload or the remote field are also present.
+ */
+function nuboot_radix_preprocess_field(&$variables) {  
+  $field_name = $variables['element']['#field_name'];
+  if ($field_name == 'field_link_api') {
+    $node = $variables['element']['#object'];
+    $resource_fields = array(
+      $node->field_link_api, 
+      $node->field_link_remote_file, 
+      $node->field_upload
+    );
+    $count = array_reduce($resource_fields, function($result, $field){
+      if(!empty($field)) {
+        $result = $result count($field);  
+      }
+      return $result;
+    }, 0);
+    
+    // If there is more than type of resource linked we have to be sure
+    // link to URL resource is not being displayed.
+    if($count > 1 && $node->field_link_api) {
+      unset($variables['element'][0]['iframe']);
+      unset($variables['items'][0]['iframe']);      
+    }
+  }
+}
+
 /**
  * Theme function for iframe link.
  */

--- a/template.php
+++ b/template.php
@@ -28,7 +28,7 @@ function nuboot_radix_preprocess_field(&$variables) {
     );
     $count = array_reduce($resource_fields, function($result, $field){
       if(!empty($field)) {
-        $result = $result count($field);  
+        $result = count($field);  
       }
       return $result;
     }, 0);


### PR DESCRIPTION
### Changes
- Fix tab styles after text modification
- Add nuboot_radix_preprocess_field when more than a resource type is present
### Acceptance criteria
- [x] Create a new resource
- [x] Link to api now it's called 'URL'. Fill this field with a http://demo.getdkan.com/dataset/wisconsin-polling-places/resource/e5a751f0-6c0a-45b8-b330-7cd75ea51f14 
- [x] Link to a file now it's called 'Remote file'. Fill this field http://demo.getdkan.com/sites/default/files/Polling_Places_Madison_0.csv
- [x] Click in save
- [x] Both resources should be saved 
- [x] In the resource view page a recline grid should be used to display the remote csv and a link to the node should be present below the grid.
