### PR TITLE
Remove url() from the group node template, the  includes any subdirec…

### DIFF
--- a/templates/node/node--group.tpl.php
+++ b/templates/node/node--group.tpl.php
@@ -22,7 +22,7 @@
   ?>
   <article class="node-teaser">
     <div class="field-name-field-image"><?php print render($group_logo); ?></div>
-    <h2 class="node-title"><a href="<?php print url($node_url) ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
+    <h2 class="node-title"><a href="<?php print $node_url ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
     <div class="content">
       <p>
         <?php $teaser = field_view_field('node', $node, 'body', array(


### PR DESCRIPTION
RE: https://github.com/NuCivic/nuboot_radix/pull/94
The fix for local urls is not needed on the node--group.tpl.php so removing it

`$node_url` on the group template already incorporates any subdirectory
