### PR TITLE
Fix link to group page on group node teaser CIVIC-4947 (release)

### DIFF
--- a/templates/node/node--group.tpl.php
+++ b/templates/node/node--group.tpl.php
@@ -33,7 +33,7 @@
         ?>
       </p>
     </div>
-    <a href="<?php print url($node_url) ?>" class="btn btn-primary"><?php print count($datasets) ?> datasets</a>
+    <a href="<?php print urldecode($node_url) ?>" class="btn btn-primary"><?php print count($datasets) ?> datasets</a>
   </article>
 
 <?php else: ?>


### PR DESCRIPTION
Issue: civic-4947

## Description
If running the site with clean urls disabled, the link for the dataset count button on group teasers will not work.

## QA Steps
1. Disable clean urls
2. Go to the 'Groups' page
3. Click the blue dataset count button on one of the groups
4. Confirm that you do not get a Page not found error, you see the group node

## Related PR
https://github.com/NuCivic/dkan/pull/1561
